### PR TITLE
fix: order the tests the same as tape

### DIFF
--- a/bin/tape-xs-build.js
+++ b/bin/tape-xs-build.js
@@ -42,7 +42,7 @@ async function main(argv, { fsp, cabinet, assets }) {
   let allDeps = [];
   const testMods = [];
 
-  for (const filename of filenames) {
+  for (const filename of filenames.sort()) {
     const deps = await moduleDeps(filename, {
       getSource: async fn => await fsp.readFile(fn, 'utf-8'),
       findModule: (specifier, fn) =>

--- a/src/tape.js
+++ b/src/tape.js
@@ -2,32 +2,6 @@
 
 const { freeze } = Object;
 
-// If you want to defer the test suites and run them after
-// loading all the test modules, use:
-//   test.deferSuites();
-// and then later:
-//   await test.runDeferredSuites();
-
-let suitesToRun = undefined;
-
-function deferSuites() {
-  suitesToRun = [];
-}
-
-async function runDeferredSuites() {
-  while (suitesToRun.length) {
-    const suite = suitesToRun.shift();
-    await suite();
-  }
-}
-
-function maybeDefer(thunk) {
-  if (!suitesToRun) {
-    return thunk();
-  }
-  suitesToRun.push(thunk);
-}
-
 // ack Paul Roub Aug 2014
 // https://stackoverflow.com/a/25456134/7963
 function deepEqual(x, y) {

--- a/tpl/main_tpl.js
+++ b/tpl/main_tpl.js
@@ -21,7 +21,7 @@ export default async function main() {
   // We use preloading to share tape's main harness.
   const htest = await tape.createHarness(pkg);
   htest.push();
-  tape.deferSuites();
+  htest.deferSuites();
 
   const modMap = { ...Compartment.map };
   delete modMap['timer']; // ISSUE: should whitelist
@@ -31,7 +31,7 @@ export default async function main() {
     // trace('built testing compartment\n');
   }
 
-  await tape.runDeferredSuites();
+  await htest.runDeferredSuites();
   htest.pop();
   const summary = await htest.result();
   console.log('Result:', summary);

--- a/tpl/main_tpl.js
+++ b/tpl/main_tpl.js
@@ -20,6 +20,7 @@ export default async function main() {
 
   // We use preloading to share tape's main harness.
   const htest = tape.createHarness(pkg);
+  tape.deferSuites();
 
   const modMap = { ...Compartment.map };
   delete modMap['timer']; // ISSUE: should whitelist
@@ -29,6 +30,7 @@ export default async function main() {
     // trace('built testing compartment\n');
   }
 
+  await tape.runDeferredSuites();
   const summary = await htest.result();
   console.log('Result:', summary);
 }

--- a/tpl/main_tpl.js
+++ b/tpl/main_tpl.js
@@ -19,7 +19,7 @@ export default async function main() {
   const { setTimeout } = makeTimer(Timer);
 
   // We use preloading to share tape's main harness.
-  const htest = tape.createHarness(pkg);
+  const htest = await tape.createHarness(pkg);
   htest.push();
   tape.deferSuites();
 

--- a/tpl/main_tpl.js
+++ b/tpl/main_tpl.js
@@ -20,6 +20,7 @@ export default async function main() {
 
   // We use preloading to share tape's main harness.
   const htest = tape.createHarness(pkg);
+  htest.push();
   tape.deferSuites();
 
   const modMap = { ...Compartment.map };
@@ -31,6 +32,7 @@ export default async function main() {
   }
 
   await tape.runDeferredSuites();
+  htest.pop();
   const summary = await htest.result();
   console.log('Result:', summary);
 }


### PR DESCRIPTION
Use the same test ordering as tape does.  Notably, we defer all the test suites, then execute them in order one by one in the main program.

This produces output much more like tape-promise.
